### PR TITLE
feat: Use package.json description in CLI help

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -8,7 +8,7 @@ function createProgram() {
   program
     .name(Object.keys(myPackage.bin)[0])
     .version(myPackage.version)
-    .description('A CLI tool to clean and format Markdown files.')
+    .description(myPackage.description)
     .configureHelp({ sortOptions: true, sortCommands: true })
     .option('-v, --verbose', 'enable verbose output')
     .option('--debug', 'enable debug output')


### PR DESCRIPTION
This commit updates the CLI description to dynamically use the description field from the package.json file. This ensures the CLI description is always up-to-date with the project's actual description and avoids duplication.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the CLI tool's description to dynamically use the `description` field from `package.json`.

### Why are these changes being made?
This change ensures that the CLI tool's help description stays consistent with the `package.json`, reducing redundancy and minimizing the risk of inconsistencies when updating project information. By centralizing the description, it improves maintainability and accuracy of the project's metadata.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->