### PR TITLE
feat: Update project structure generation and insertion in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,11 @@ Clean the Markdown file by removing unnecessary elements.
 
 ---
 
-<!-- PROJECT_STRUCTURE_START -->
 ## 🌳 Project Structure
+
+Here is what I have in mind
+
+<!-- PROJECT_STRUCTURE_START -->
 
 ```
 .
@@ -128,6 +131,7 @@ This project is licensed under the [MIT License](LICENSE).
 We would like to thank the creators and maintainers of the following libraries and tools, which were instrumental in the development of this CLI and the management of its repository:
 
 <!-- ACKNOWLEDGMENTS_START -->
+
 - [commander](https://www.npmjs.com/package/commander) - the complete solution for node.js command-line programs
 - [doctrine](https://www.npmjs.com/package/doctrine) - JSDoc parser
 - [espree](https://www.npmjs.com/package/espree) - An Esprima-compatible JavaScript parser built on Acorn

--- a/src/utils/generate-tree.js
+++ b/src/utils/generate-tree.js
@@ -66,22 +66,36 @@ function updateReadme() {
   const startIndex = readmeContent.indexOf(startMarker);
   const endIndex = readmeContent.indexOf(endMarker);
 
-  if (startIndex !== -1 && endIndex !== -1) {
-    const before = readmeContent.substring(0, startIndex);
-    const after = readmeContent.substring(endIndex + endMarker.length);
+  const projectTreeOnly = "```\n" + projectTree + "```";
 
-    readmeContent = `${before}${startMarker}\n${projectStructureSection}\n${endMarker}${after}`;
+  if (startIndex !== -1 && endIndex !== -1) {
+    const blockStartIndex = startIndex + startMarker.length;
+    const blockEndIndex = endIndex;
+    const blockContent = readmeContent.substring(
+      blockStartIndex,
+      blockEndIndex,
+    );
+
+    const treeRegex = /```[\s\S]*?```/;
+    const newBlockContent = blockContent.replace(treeRegex, projectTreeOnly);
+
+    const before = readmeContent.substring(0, blockStartIndex);
+    const after = readmeContent.substring(blockEndIndex);
+
+    readmeContent = `${before}${newBlockContent}${after}`;
   } else {
     // Add new section before Community & Support
     const communitySupportHeading = "## 💬 Community & Support";
+    const newSection = `## 🌳 Project Structure\n\n${startMarker}\n${projectTreeOnly}\n${endMarker}`;
+
     if (readmeContent.includes(communitySupportHeading)) {
       readmeContent = readmeContent.replace(
         communitySupportHeading,
-        `${startMarker}\n${projectStructureSection}\n${endMarker}\n\n---\n\n${communitySupportHeading}`,
+        `${newSection}\n\n---\n\n${communitySupportHeading}`,
       );
     } else {
       // If Community & Support not found, append at the end
-      readmeContent += `\n\n---\n\n${startMarker}\n${projectStructureSection}\n${endMarker}`;
+      readmeContent += `\n\n---\n\n${newSection}`;
     }
   }
 


### PR DESCRIPTION
This commit updates the project structure generation in `src/utils/generate-tree.js` and improves how it's inserted into the README.md file.

Previously, the project structure was directly injected into the README, potentially overwriting any surrounding text or markdown elements.  This commit refactors the updateReadme function to:

- Target specifically the code block containing the project tree within the start and end markers.
- Replace only the code block content with the newly generated tree.
- If the start and end markers are not found, it appends the section before the Community & Support section or at the end of the file, ensuring backward compatibility.

In addition, the README.md file was adjusted to include an introductory sentence before the 'Project Structure' section, providing context for the generated tree.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the project structure generation logic in `generate-tree.js` and insert enhanced project structure details into the `README.md`.

### Why are these changes being made?

To improve the automation and clarity of project structure documentation in `README.md` by refining how the project structure is identified, replaced, or added. The new approach ensures that the project tree is correctly inserted using a predefined template, enhancing maintainability and accuracy of project documentation.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->