### PR TITLE
docs: Remove project structure placeholder from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ Clean the Markdown file by removing unnecessary elements.
 [//]: # (You can add your Markdown content here. This comment can be safely removed by deleting this line.)
 
 <!-- PROJECT_STRUCTURE_START -->
-
 ```
 .
 ├── .vscode
@@ -101,7 +100,6 @@ Clean the Markdown file by removing unnecessary elements.
 ├── package.json
 └── README.md
 ```
-
 <!-- PROJECT_STRUCTURE_END -->
 
 ---

--- a/src/utils/generate-tree.js
+++ b/src/utils/generate-tree.js
@@ -86,7 +86,13 @@ function updateReadme() {
   } else {
     // Add new section before Community & Support
     const communitySupportHeading = "## 💬 Community & Support";
-    const newSection = `## 🌳 Project Structure\n\n${startMarker}\n${projectTreeOnly}\n${endMarker}`;
+    const newSection = `## 🌳 Project Structure
+
+[//]: # (You can add your Markdown content here. This comment can be safely removed by deleting this line.)
+
+${startMarker}
+${projectTreeOnly}
+${endMarker}`;
 
     if (readmeContent.includes(communitySupportHeading)) {
       readmeContent = readmeContent.replace(


### PR DESCRIPTION
The placeholder comment suggesting where to add the project structure description is removed.
This removes unnecessary boilerplate from the documentation and adds it to generate-tree.js.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the project structure placeholder from the README and update the `generate-tree.js` script to include a hidden comment for Markdown content in the project structure section.

### Why are these changes being made?

The placeholder in the README was unnecessary and cluttered the document; its removal improves readability. The update in `generate-tree.js` introduces a hidden comment allowing for additional non-visual annotations or instructions within the project structure section, enhancing maintenance and clarity for future updates.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->